### PR TITLE
Remove debug symbols when compiling x2t

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -721,7 +721,6 @@ RUN cat /wrap-main.cpp >> /core/X2tConverter/src/main.cpp
 # ENV DEV_MODE=1
 RUN --mount=type=cache,sharing=locked,target=/emsdk/upstream/emscripten/cache/ \
     embuild.sh \
-    -c -g \
     -l "-lgumbo" \
     -l "-lkatana" \
     -l "-looxmlsignature" \


### PR DESCRIPTION
Remove the debug symbols when compiling x2t. This improve the size of the binary by about ~20MB, which in turn makes Firefox able to cache it by default.

I've tested it with a local Cryptpad instance in integration mode by swapping the binary, and I haven't found any problem.
